### PR TITLE
add 'preview' Quarto profile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,8 @@ jobs:
         uses: quarto-dev/quarto-actions/publish@v2
         with:
           target: gh-pages
+        env:
+          QUARTO_PROFILE: preview
 
       - name: Update cynkrablog S3 bucket
         if: github.event_name == 'push'

--- a/_quarto-preview.yml
+++ b/_quarto-preview.yml
@@ -1,0 +1,6 @@
+
+format:
+  html:
+    include-in-header:
+      - text: |
+          <meta name="robots" content="noindex">


### PR DESCRIPTION
Fix #40

The preview pages like https://cynkra.github.io/cynkrablog/ or https://cynkra.github.io/cynkrablog/blog/posts/2022-05-14-accessing-google-api-via-oauth2/ have this line in head `<meta name="robots" content="noindex">`