### PR TITLE
Save lychee cache only when there are no failures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
           message: ${{ steps.lychee-output.outputs.content }}
 
       - name: Save lychee cache
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         if: success()
         with:
           path: .lycheecache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Save lychee cache
         uses: actions/cache/save@v3
-        if: always()
+        if: success()
         with:
           path: .lycheecache
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
An idea to tackle https://github.com/cynkra/cynkrablog/pull/42#issuecomment-1891648308

There were false positives in the PR. To avoid them, I only knew one solution: opening another PR with the same changes.